### PR TITLE
bundle before publishing so npm wont need to resolve dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 node_modules/
-dist/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.1",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "build": "ncc build index.js",
+    "prepublish": "npm run build"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -12,12 +15,12 @@
     "url": "git@github.com:Jephuff/print-npm-scripts.git"
   },
   "bin": {
-    "print-pkg-scripts": "./index.js"
+    "print-pkg-scripts": "./dist/index.js"
   },
-  "dependencies": {
+  "devDependencies": {
     "ansi-colors": "3.2.3",
     "execa": "1.0.0",
-    "inquirer": "6.2.2",
-    "read-pkg-up": "^4.0.0"
+    "read-pkg-up": "^4.0.0",
+    "@zeit/ncc": "0.14.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/Jephuff/print-npm-scripts/issues/6

This PR makes using the binary via `npx` faster

The script is bundled before publishing via [ncc](https://zeit.co/blog/ncc)

All dependencies have been moved to devDependencies

First-run time down from ~5s to ~2.3s
![image](https://user-images.githubusercontent.com/743976/52524340-e19f1c00-2c69-11e9-9a29-abb16884c41f.png)
Subsequent runs take ~1.3s
![image](https://user-images.githubusercontent.com/743976/52524349-f4b1ec00-2c69-11e9-836e-3a0e15e76440.png)
